### PR TITLE
Td mpi gammamat

### DIFF
--- a/src/dftbp/dftb/shortgamma.F90
+++ b/src/dftbp/dftb/shortgamma.F90
@@ -258,7 +258,7 @@ contains
 
 
   !> Adds the atom resolved interaction matrix
-  subroutine addAtomicMatrix(this, gammamat, iNeighbour, img2CentCell)
+  subroutine addAtomicMatrix(this, gammamat, iNeighbour, img2CentCell, iAt, jAt)
 
     !> Instance
     class(TShortGamma), intent(in) :: this
@@ -272,14 +272,28 @@ contains
     !> Mapping of the atoms into the central cell
     integer, intent(in) :: img2CentCell(:)
 
+    !> Optional pair of atoms for which to evaluate and add interaction
+    integer, intent(in), optional :: iAt, jAt
+
     integer :: iAt1, iAt2f, iNeigh
 
-    do iAt1 = 1, this%nAtom_
-      do iNeigh = 0, maxval(this%nNeigh_(:,:,:, iAt1))
-        iAt2f = img2CentCell(iNeighbour(iNeigh, iAt1))
-        gammamat(iAt2f, iAt1) = gammamat(iAt2f, iAt1) - this%shortGamma_(1, 1, iNeigh, iAt1)
+    if (present(jAt)) then
+      @:ASSERT(present(iAt))
+      @:ASSERT(iAt >= jAt)
+      do iNeigh = 0, maxval(this%nNeigh_(:,:,:, jAt))
+        iAt2f = img2CentCell(iNeighbour(iNeigh, jAt))
+        if (iAt2f == iAt) then
+          gammamat(iAt, jAt) = gammamat(iAt, jAt) - this%shortGamma_(1, 1, iNeigh, jAt)
+        end if
       end do
-    end do
+    else
+      do iAt1 = 1, this%nAtom_
+        do iNeigh = 0, maxval(this%nNeigh_(:,:,:, iAt1))
+          iAt2f = img2CentCell(iNeighbour(iNeigh, iAt1))
+          gammamat(iAt2f, iAt1) = gammamat(iAt2f, iAt1) - this%shortGamma_(1, 1, iNeigh, iAt1)
+        end do
+      end do
+    end if
 
   end subroutine addAtomicMatrix
 

--- a/test/app/dftb+/timedep/2CH3-Temp-Stratmann/dftb_in.hsd
+++ b/test/app/dftb+/timedep/2CH3-Temp-Stratmann/dftb_in.hsd
@@ -44,5 +44,5 @@ Parallel {
   # Allow OMP threads explicitely to test for hybrid parallelisation with
   # MPI-binary. (Check the manual before using this in production runs!)
   UseOmpThreads = Yes
+  Blacs = BlockSize {4} # Very small to allow 2 procs
 }
-

--- a/test/app/dftb+/timedep/C4H6-Singlet/dftb_in.hsd
+++ b/test/app/dftb+/timedep/C4H6-Singlet/dftb_in.hsd
@@ -38,5 +38,6 @@ Parallel {
   # Allow OMP threads explicitely to test for hybrid parallelisation with
   # MPI-binary. (Check the manual before using this in production runs!)
   UseOmpThreads = Yes
+  Blacs = BlockSize {8} # Very small to allow 2 procs
 }
 

--- a/test/app/dftb+/timedep/C4H6-Triplet/dftb_in.hsd
+++ b/test/app/dftb+/timedep/C4H6-Triplet/dftb_in.hsd
@@ -42,5 +42,6 @@ Parallel {
   # Allow OMP threads explicitely to test for hybrid parallelisation with
   # MPI-binary. (Check the manual before using this in production runs!)
   UseOmpThreads = Yes
+  Blacs = BlockSize {8} # Very small to allow 2 procs
 }
 

--- a/test/app/dftb+/timedep/C6H6-Sym/dftb_in.hsd
+++ b/test/app/dftb+/timedep/C6H6-Sym/dftb_in.hsd
@@ -38,5 +38,5 @@ Parallel {
   # Allow OMP threads explicitely to test for hybrid parallelisation with
   # MPI-binary. (Check the manual before using this in production runs!)
   UseOmpThreads = Yes
+  Blacs = BlockSize {8} # Very small to allow 2 procs
 }
-

--- a/test/app/dftb+/timedep/C6H6-Sym_Arnoldi/dftb_in.hsd
+++ b/test/app/dftb+/timedep/C6H6-Sym_Arnoldi/dftb_in.hsd
@@ -39,5 +39,5 @@ Parallel {
   # Allow OMP threads explicitely to test for hybrid parallelisation with
   # MPI-binary. (Check the manual before using this in production runs!)
   UseOmpThreads = Yes
+  Blacs = BlockSize {8} # Very small to allow 2 procs
 }
-

--- a/test/app/dftb+/timedep/cyclopentadienyl/dftb_in.hsd
+++ b/test/app/dftb+/timedep/cyclopentadienyl/dftb_in.hsd
@@ -58,5 +58,5 @@ Parallel {
   # Allow OMP threads explicitely to test for hybrid parallelisation with
   # MPI-binary. (Check the manual before using this in production runs!)
   UseOmpThreads = Yes
+  Blacs = BlockSize {8} # Very small to allow 2 procs
 }
-


### PR DESCRIPTION
Improved parallelism for the gamma matrix return routine.

* Loops now run only over local parts of the matrix.
* Short range contribution is now parallelised.
* Explicitly generates the lower triangle (as it is used in symm() ops afterwards).
* Modify block sizes in test cases that were listed as running on 2 processors. Note: as a result discovered two of those tests fail on 2 processors with unmodified code from before this PR.