### PR TITLE
Add timers for some of linear response process

### DIFF
--- a/src/dftbp/common/environment.F90
+++ b/src/dftbp/common/environment.F90
@@ -92,7 +92,8 @@ module dftbp_common_environment
 
   end type TEnvironment
 
-  type(TTimerItem), parameter :: globalTimerItems(25) = [&
+  !> Timers and their required verbosity levels. Order must match the helper index type
+  type(TTimerItem), parameter :: globalTimerItems(33) = [&
       & TTimerItem("Global initialisation", 1),&
       & TTimerItem("Pre-SCC initialisation", 1),&
       & TTimerItem("Sparse H0 and S build", 4),&
@@ -117,9 +118,19 @@ module dftbp_common_environment
       & TTimerItem("Stress calculation", 2),&
       & TTimerItem("Post-geometry optimisation", 1),&
       & TTimerItem("Electron dynamics initialisation", 2),&
-      & TTimerItem("Electron dynamics loop", 2)&
+      & TTimerItem("Electron dynamics loop", 2),&
+      & TTimerItem("Linear response excitation", 2),&
+      & TTimerItem("Linear response setup", 3),&
+      & TTimerItem("Linear response coulomb", 4),&
+      & TTimerItem("Linear response transition charges", 4),&
+      & TTimerItem("Linear response solver", 3),&
+      & TTimerItem("Linear response Z vector", 3),&
+      & TTimerItem("Linear response gradients", 3),&
+      & TTimerItem("Linear response NAC", 3)&
       & ]
 
+
+  !> Numerical identifiers to distinguish timers, matching labels above
   type :: TGlobalTimersHelper
     integer :: globalInit = 1
     integer :: preSccInit = 2
@@ -146,9 +157,18 @@ module dftbp_common_environment
     integer :: postGeoOpt = 23
     integer :: elecDynInit = 24
     integer :: elecDynLoop = 25
-
+    integer :: lrExcitation = 26
+    integer :: lrSetup = 27
+    integer :: lrCoulomb = 28
+    integer :: lrTransCharges = 29
+    integer :: lrSolver = 30
+    integer :: lrZVector = 31
+    integer :: lrGradients = 32
+    integer :: lrNAC = 33
   end type TGlobalTimersHelper
 
+
+  !> Instance of timer labels
   type(TGlobalTimersHelper), parameter :: globalTimers = TGlobalTimersHelper()
 
 

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -1412,6 +1412,7 @@ contains
     call env%globalTimer%startTimer(globalTimers%postSCC)
 
     if (this%isLinResp) then
+      call env%globalTimer%startTimer(globalTimers%lrExcitation)
       call calculateLinRespExcitations(env, this%linearResponse, this%parallelKS, this%scc,&
           & this%qOutput, this%q0, this%ints, this%eigvecsReal, this%eigen(:,1,:),&
           & this%filling(:,1,:), this%coord, this%species, this%speciesName, this%orb,&
@@ -1421,6 +1422,7 @@ contains
           & this%tPrintExcitedEigvecs, this%tPrintEigvecsTxt, this%nonSccDeriv,&
           & this%dftbEnergy(1), this%energiesCasida, this%SSqrReal, this%rhoSqrReal,&
           & this%deltaRhoOutSqr, this%excitedDerivs, this%occNatural, this%rangeSep)
+      call env%globalTimer%stopTimer(globalTimers%lrExcitation)
     end if
 
     if (allocated(this%ppRPA)) then
@@ -4405,7 +4407,7 @@ contains
       & excitedDerivs, occNatural, rangeSep)
 
     !> Environment settings
-    type(TEnvironment), intent(in) :: env
+    type(TEnvironment), intent(inout) :: env
 
     !> excited state settings
     type(TLinResp), intent(inout), allocatable :: linearResponse

--- a/src/dftbp/timedep/linresp.F90
+++ b/src/dftbp/timedep/linresp.F90
@@ -242,12 +242,12 @@ contains
 
 
   !> Wrapper to call the actual linear response routine for excitation energies
-  subroutine linResp_calcExcitations(env, this, tSpin, denseDesc, eigVec, eigVal, SSqrReal, filling,&
-      & coords0, sccCalc, dqAt, species0, iNeighbour, img2CentCell, orb, tWriteTagged, fdTagged,&
-      & taggedWriter, rangeSep, excEnergy, allExcEnergies)
+  subroutine linResp_calcExcitations(env, this, tSpin, denseDesc, eigVec, eigVal, SSqrReal,&
+      & filling, coords0, sccCalc, dqAt, species0, iNeighbour, img2CentCell, orb, tWriteTagged,&
+      & fdTagged, taggedWriter, rangeSep, excEnergy, allExcEnergies)
 
     !> Environment settings
-    type(TEnvironment), intent(in) :: env
+    type(TEnvironment), intent(inout) :: env
     
     !> data structure with additional linear response values
     type(TLinresp), intent(inout) :: this
@@ -330,7 +330,7 @@ contains
       & derivator, rhoSqr, deltaRho, occNatural, naturalOrbs)
 
     !> Environment settings
-    type(TEnvironment), intent(in) :: env
+    type(TEnvironment), intent(inout) :: env
     
     !> is this a spin-polarized calculation
     logical, intent(in) :: tSpin
@@ -427,14 +427,14 @@ contains
       shiftPerAtom = shiftPerAtom + shiftPerL(1,:)
 
       if (allocated(occNatural)) then
-        call LinRespGrad_old(env, this, denseDesc, eigVec, eigVal, sccCalc, dqAt, coords0, SSqrReal,&
-            & filling, species0, iNeighbour, img2CentCell, orb, fdTagged, taggedWriter, rangeSep,&
-            & excEnergy, allExcEnergies, deltaRho, shiftPerAtom, skHamCont, skOverCont,&
+        call LinRespGrad_old(env, this, denseDesc, eigVec, eigVal, sccCalc, dqAt, coords0,&
+            & SSqrReal, filling, species0, iNeighbour, img2CentCell, orb, fdTagged, taggedWriter,&
+            & rangeSep, excEnergy, allExcEnergies, deltaRho, shiftPerAtom, skHamCont, skOverCont,&
             & excgradient, derivator, rhoSqr, occNatural, naturalOrbs)
       else
-        call LinRespGrad_old(env, this, denseDesc, eigVec, eigVal, sccCalc, dqAt, coords0, SSqrReal,&
-            & filling, species0, iNeighbour, img2CentCell, orb, fdTagged, taggedWriter, rangeSep,&
-            & excEnergy, allExcEnergies, deltaRho, shiftPerAtom, skHamCont, skOverCont,&
+        call LinRespGrad_old(env, this, denseDesc, eigVec, eigVal, sccCalc, dqAt, coords0,&
+            & SSqrReal, filling, species0, iNeighbour, img2CentCell, orb, fdTagged, taggedWriter,&
+            & rangeSep, excEnergy, allExcEnergies, deltaRho, shiftPerAtom, skHamCont, skOverCont,&
             & excgradient, derivator, rhoSqr)
       end if
 

--- a/src/dftbp/timedep/linrespcommon.F90
+++ b/src/dftbp/timedep/linrespcommon.F90
@@ -471,7 +471,7 @@ contains
     integer, intent(in) :: getAB(:,:)
 
     !> Environment settings
-    type(TEnvironment), intent(in) :: env
+    type(TEnvironment), intent(inout) :: env
 
     !> Dense matrix descriptor
     type(TDenseDescr), intent(in) :: denseDesc 
@@ -774,7 +774,7 @@ contains
     integer, intent(in) :: getAB(:,:)
 
     !> Environment settings
-    type(TEnvironment), intent(in) :: env
+    type(TEnvironment), intent(inout) :: env
 
     !> Dense matrix descriptor
     type(TDenseDescr), intent(in) :: denseDesc 
@@ -1120,7 +1120,7 @@ contains
     integer, intent(in) :: getAB(:,:)
 
     !> Environment settings
-    type(TEnvironment), intent(in) :: env
+    type(TEnvironment), intent(inout) :: env
 
     !> Dense matrix descriptor
     type(TDenseDescr), intent(in) :: denseDesc
@@ -1281,7 +1281,7 @@ contains
     integer, intent(in) :: win(:)
 
     !> Environment settings
-    type(TEnvironment), intent(in) :: env
+    type(TEnvironment), intent(inout) :: env
 
     !> Dense matrix descriptor
     type(TDenseDescr), intent(in) :: denseDesc 
@@ -1483,7 +1483,7 @@ contains
       & ovrXev, grndEigVecs, ons_en, orb, vin, vout, indexOffSet)
 
     !> Environment settings
-    type(TEnvironment), intent(in) :: env
+    type(TEnvironment), intent(inout) :: env
     
     !> logical spin polarization
     logical, intent(in) :: spin
@@ -1801,7 +1801,7 @@ contains
     integer, intent(in) :: nmatup
 
     !> Environment settings
-    type(TEnvironment), intent(in) :: env
+    type(TEnvironment), intent(inout) :: env
 
     !> Dense matrix descriptor
     type(TDenseDescr), intent(in) :: denseDesc 
@@ -1994,7 +1994,7 @@ contains
     & filling, ovrXev, grndEigVecs)
 
     !> Environment settings
-    type(TEnvironment), intent(in) :: env
+    type(TEnvironment), intent(inout) :: env
 
     !> Dense matrix descriptor
     type(TDenseDescr), intent(in) :: denseDesc 
@@ -2536,7 +2536,7 @@ contains
   subroutine local2GlobalBlacsArray(env, denseDesc, locArray, glbArray)
 
     !> Environment settings
-    type(TEnvironment), intent(in) :: env
+    type(TEnvironment), intent(inout) :: env
 
     !> Dense matrix descriptor
     type(TDenseDescr), intent(in) :: denseDesc


### PR DESCRIPTION
Introduces timers for several stages of the linear response calculations.

Timing with a C320 molecule shows that the transition charge routine is much worse scaling than the actual solver.